### PR TITLE
Add logging to viewer-request CloudFront Function

### DIFF
--- a/lambdas/src/cloudfront-function/viewer-request.ts
+++ b/lambdas/src/cloudfront-function/viewer-request.ts
@@ -5,6 +5,10 @@ import Response = AWSCloudFrontFunction.Response
 export const handler = async (event: Event): Promise<Request | Response> => {
   const request = event.request
   if (!request) throw new Error('Missing request.')
+  if (request.uri === '/') {
+    console.log(event.viewer)
+    console.log(JSON.stringify(request, null, 2))
+  }
   if (
     request.uri !== '/' &&
     (request.uri.endsWith('/') ||

--- a/terraform/modules/static_website/main.tf
+++ b/terraform/modules/static_website/main.tf
@@ -85,11 +85,19 @@ resource "aws_cloudfront_origin_access_control" "static_website" {
   signing_protocol                  = "sigv4"
 }
 
+resource "aws_cloudwatch_log_group" "static_website_viewer_request" {
+  provider          = aws.us-east-1
+  name              = "/aws/cloudfront/function/${replace(var.domain_name, ".", "_")}-viewer-request"
+  retention_in_days = 30
+  tags              = var.common_tags
+}
+
 resource "aws_cloudfront_function" "static_website_viewer_request" {
-  name    = "${replace(var.domain_name, ".", "_")}-viewer-request"
-  runtime = "cloudfront-js-2.0"
-  code    = file("${path.root}/../lambdas/dist/viewer-request.js")
-  publish = true
+  depends_on = [aws_cloudwatch_log_group.static_website_viewer_request]
+  name       = "${replace(var.domain_name, ".", "_")}-viewer-request"
+  runtime    = "cloudfront-js-2.0"
+  code       = file("${path.root}/../lambdas/dist/viewer-request.js")
+  publish    = true
 }
 
 resource "aws_cloudfront_distribution" "static_website" {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above in the format "<TICKET-ID>: <Short summary of Ticket>" -->

### Pull Request Status 🤔
<!-- What is the status of this PR? Check the box that applies: [x] -->
- [x] Ready :rocket:
- [ ] Work in Progress :construction:
- [ ] Hold :anchor:

<!-- If this PR is on hold, please elaborate below this line with :warning:. -->
<!-- If PR isn't ready, use Draft mode, WIP label and/or [WIP] in the title -->

### Types of changes 🦋
<!-- What types of changes does your code introduce? -->
<!-- Note that your changes may fall into multiple categories. -->
- [ ] :hammer:Breaking
- [ ] :bug:Fix
- [x] :sparkles:New Feature
- [ ] 🧪Testing
- [ ] ⚙️Configuration
- [ ] 📖Documentation

### Description ℹ️
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
Contained in this PR are changes to add logging to the `viewer-request` CloudFront Function. The `viewer-request` CloudFront Function will now log the `event.viewer` and `event.request` objects in CloudWatch, only if the request is the root `/` (we do not want several duplicate logs from the same user but different resources). 

### Checklist :checkered_flag:
<!-- Check the boxes that apply to this PR -->
- [ ] My change requires new dependencies
- [x] My change requires new tests which I have created
- [x] My change requires updating existing tests which I have done

<!-- If you have any screenshots relevant to this PR, uncomment this section and add the images below -->
<!-- ### Screenshots: -->

